### PR TITLE
feature(local-redux-store): dispatch accepts Observable

### DIFF
--- a/packages/local-redux-store-demo/src/app/slide-show/slide-show.component.ts
+++ b/packages/local-redux-store-demo/src/app/slide-show/slide-show.component.ts
@@ -12,8 +12,7 @@ import {
   updateSpeed
 } from "./slideshow-store.service";
 import { FormControl, FormGroup } from "@angular/forms";
-import { Subject, takeUntil } from "rxjs";
-
+import { map, Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-slide-show',
@@ -29,6 +28,10 @@ export class SlideShowComponent {
     speed: this.speedFc,
   });
 
+  private updateSpeedAction$ = this.speedFc.valueChanges.pipe(
+    map(v => updateSpeed(v))
+  )
+
   @Input()
   set photos(photos: string[]) {
     this.store.dispatch(updatePhotos(photos));
@@ -40,9 +43,7 @@ export class SlideShowComponent {
       .pipe(takeUntil(this.destroy))
       .subscribe((v) => this.speedFc.setValue(v));
 
-    this.speedFc.valueChanges
-      .pipe(takeUntil(this.destroy))
-      .subscribe((v) => this.store.dispatch(updateSpeed(v)));
+    this.store.dispatch(this.updateSpeedAction$);
   }
 
   ngOnDestroy(): void {

--- a/packages/local-redux-store/src/lib/local-redux-store.ts
+++ b/packages/local-redux-store/src/lib/local-redux-store.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, map, Observable, observeOn, queueScheduler, Subject, Subscription } from "rxjs";
+import { BehaviorSubject, isObservable, map, Observable, observeOn, queueScheduler, Subject, Subscription } from 'rxjs';
 import { Action, Actions, Reducer } from "./models";
 import { select } from "./utils";
 import { defaultEffectsErrorHandler } from "./default-effects-error-handler";
@@ -26,8 +26,12 @@ export class LocalReduxStore<T extends object> {
     this.dispatch({type: 'init-store'})
   }
 
-  dispatch(action: Action) {
-    this.actionsSource.next(action);
+  dispatch(action: Action | Observable<Action>) {
+    if (isObservable(action)) {
+      this.sub.add(action.subscribe(this.actionsSource))
+    } else {
+      this.actionsSource.next(action);
+    }
   }
 
   select<R>(mapFn: (state: T) => R): Observable<R> {


### PR DESCRIPTION
Usage:

```Typescript
export class SlideShowComponent {
  private speedFc = new FormControl();

  private updateSpeedAction$ = this.speedFc.valueChanges.pipe(
    map(v => updateSpeed(v))
  )

  constructor(public store: SlideshowStoreService) {
    this.store.dispatch(this.updateSpeedAction$);
  }
}
```

When updateSpeedAction$ (this.speedFc.valueChanges) emits, an updateSpeed action will be dispatched to the store.